### PR TITLE
Proposal for optionals behavior

### DIFF
--- a/README.org
+++ b/README.org
@@ -286,7 +286,8 @@ it.
 
 * Enums and Unions
 
-  Hodur enums are spec'd as exact strings. Therefore the hodur model below:
+  Hodur enums are spec'd as exact keywords or strings. Therefore the hodur
+  model below:
 
 #+BEGIN_SRC clojure
   '[^:enum
@@ -295,7 +296,7 @@ it.
 #+END_SRC
 
   Will create two specs where one of them would be along the lines of
-  ~:app.core.gender/female~ where ~#(= "FEMALE" %)~ (one for female
+  ~:app.core.gender/female~ where ~#(= "FEMALE" (name %))~ (one for female
   and one for male).
 
   The enum per se is an ~s/or~ between all of the enum's options.

--- a/src/hodur_spec_schema/core.clj
+++ b/src/hodur_spec_schema/core.clj
@@ -229,7 +229,7 @@
 
 (defmethod get-spec-form* :enum-entry
   [{:keys [field/name]} _]
-  `#(= ~name %))
+  `#(= ~name (name %)))
 
 (defmethod get-spec-form* :union-field
   [{:keys [field/union-type]} opts]

--- a/src/hodur_spec_schema/core.clj
+++ b/src/hodur_spec_schema/core.clj
@@ -128,6 +128,12 @@
 (defmulti ^:private get-spec-form*
   (fn [obj opts]
     (cond
+      (:field/optional obj)
+      :optional-field
+
+      (:param/optional obj)
+      :optional-param
+
       (many-cardinality? obj)
       :many-ref
       
@@ -228,6 +234,16 @@
 (defmethod get-spec-form* :union-field
   [{:keys [field/union-type]} opts]
   (get-spec-name union-type opts))
+
+(defmethod get-spec-form* :optional-param
+  [obj opts]
+  (let [entity-spec (get-spec-form (dissoc obj :param/optional) opts)]
+    (list* `s/nilable [entity-spec])))
+
+(defmethod get-spec-form* :optional-field
+  [obj opts]
+  (let [entity-spec (get-spec-form (dissoc obj :field/optional) opts)]
+    (list* `s/nilable [entity-spec])))
 
 (defmethod get-spec-form* :entity
   [{:keys [field/_parent type/implements]} opts]

--- a/test/core_test.clj
+++ b/test/core_test.clj
@@ -166,6 +166,7 @@
     (is (s/valid? :core-test/animal {:race "Human"}))
 
     (is (s/valid? :core-test.person.height/unit "METERS"))
+    (is (s/valid? :core-test.person.height/unit :METERS))
 
     (is (s/valid? :core-test/pet {:name "bla" :dob #inst "2000-10-10" :race "cat"}))
 

--- a/test/core_test.clj
+++ b/test/core_test.clj
@@ -83,6 +83,10 @@
     [^{:type String
        :cardinality [0 n]}
      many-strings
+     ^{:type String
+       :optional true
+       :cardinality [0 n]}
+     many-strings-optional
      ^{:type GenderTwo
        :cardinality [0 n]}
      many-genders
@@ -171,6 +175,7 @@
                                      :height 1.78}))
 
     (is (not (s/valid? :core-test/person {:firs-name "Tiago"
+                                          :middle-name nil
                                           :last-name "Luchini"
                                           :gender "MALE"
                                           :height 1.78})))
@@ -216,6 +221,10 @@
   (is (s/valid? :core-test.cardinality-entity/many-strings []))
 
   (is (s/valid? :core-test.cardinality-entity/many-strings ["foo" "bar"]))
+
+  (is (s/valid? :core-test.cardinality-entity/many-strings-optional nil))
+  (is (s/valid? :core-test.cardinality-entity/many-strings-optional []))
+  (is (s/valid? :core-test.cardinality-entity/many-strings-optional ["foo" "bar"]))
 
   (is (s/valid? :core-test.cardinality-entity/many-genders ["MALE" "UNKOWN"]))
 


### PR DESCRIPTION
- For fields which are optionals, accept the key to be on the map, but without value (`nil`)
- Accept params to be optional, having a `nil` arg
- Update for `unions`, which could accept the exact string or keyword